### PR TITLE
build(pom.xml): restructure plugin configurations into a release prof…

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.releaseversion }}" == *-SNAPSHOT ]]; then
             echo "Deploying SNAPSHOT version"
-            mvn -s .mvn/.m2/settings.xml --batch-mode clean deploy --no-transfer-progress -DskipTests -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+            mvn -s .mvn/.m2/settings.xml --batch-mode clean deploy -Prelease --no-transfer-progress -DskipTests -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
           else
             echo "Deploying RELEASE version"
-            mvn -s .mvn/.m2/settings.xml --batch-mode clean deploy -P release --no-transfer-progress -DskipTests -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+            mvn -s .mvn/.m2/settings.xml --batch-mode clean deploy -Prelease --no-transfer-progress -DskipTests -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
           fi

--- a/pom.xml
+++ b/pom.xml
@@ -120,36 +120,46 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                            <useAgent>false</useAgent>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                    <useAgent>false</useAgent>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
…ile (main)

- Moved maven-gpg-plugin and central-publishing-maven-plugin configurations into a dedicated 'release' profile.
- Adjusted GitHub workflow to use the 'release' profile for deployments.
- This change enhances build management and artifact deployment processes.