### PR TITLE
refactor(security): replace PluginAuthorize with Authorize annotation…

### DIFF
--- a/quartz-bungee-plugin-starter/src/main/java/xyz/quartzframework/bungee/security/BungeeSecurityAspect.java
+++ b/quartz-bungee-plugin-starter/src/main/java/xyz/quartzframework/bungee/security/BungeeSecurityAspect.java
@@ -17,7 +17,7 @@ import xyz.quartzframework.bungee.session.BungeeSession;
 import xyz.quartzframework.bungee.session.BungeeSessionService;
 import xyz.quartzframework.core.exception.PermissionDeniedException;
 import xyz.quartzframework.core.exception.PlayerNotFoundException;
-import xyz.quartzframework.core.security.PluginAuthorize;
+import xyz.quartzframework.core.security.Authorize;
 import xyz.quartzframework.core.util.AopAnnotationUtils;
 
 import java.util.Map;
@@ -39,10 +39,10 @@ public class BungeeSecurityAspect {
 
     private final ExpressionParser parser = new SpelExpressionParser();
 
-    @Around("within(@(@xyz.quartzframework.core.security.PluginAuthorize *) *) " +
-            "|| execution(@(@xyz.quartzframework.core.security.PluginAuthorize *) * *(..)) " +
-            "|| @within(xyz.quartzframework.core.security.PluginAuthorize)" +
-            "|| execution(@xyz.quartzframework.core.security.PluginAuthorize * *(..))")
+    @Around("within(@(@xyz.quartzframework.core.security.Authorize *) *) " +
+            "|| execution(@(@xyz.quartzframework.core.security.Authorize *) * *(..)) " +
+            "|| @within(xyz.quartzframework.core.security.Authorize)" +
+            "|| execution(@xyz.quartzframework.core.security.Authorize * *(..))")
     public Object checkPermission(ProceedingJoinPoint joinPoint) throws Throwable {
         val sender = session.getSender();
         if (sender == null) {
@@ -54,7 +54,7 @@ public class BungeeSecurityAspect {
         IntStream.range(0, parameters.length)
                 .forEach(i -> senderContext.setVariable(parameters[i].getName(), joinPoint.getArgs()[i]));
         senderContext.setVariable("session", sessionService.current());
-        AopAnnotationUtils.getApplicableAnnotations(method, PluginAuthorize.class).forEach(pluginAuthorize -> {
+        AopAnnotationUtils.getApplicableAnnotations(method, Authorize.class).forEach(pluginAuthorize -> {
             val expressionSource = pluginAuthorize.value();
             val expression = expressionCache.computeIfAbsent(expressionSource, parser::parseExpression);
             senderContext.setVariable("params", pluginAuthorize.params());

--- a/quartz-bungee-plugin-starter/src/main/java/xyz/quartzframework/bungee/security/ProxiedPlayerOnly.java
+++ b/quartz-bungee-plugin-starter/src/main/java/xyz/quartzframework/bungee/security/ProxiedPlayerOnly.java
@@ -2,7 +2,7 @@ package xyz.quartzframework.bungee.security;
 
 import org.springframework.core.annotation.AliasFor;
 import xyz.quartzframework.core.exception.PermissionDeniedException;
-import xyz.quartzframework.core.security.PluginAuthorize;
+import xyz.quartzframework.core.security.Authorize;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,14 +14,14 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PluginAuthorize("#root instanceof T(net.md_5.bungee.api.connection.ProxiedPlayer)")
+@Authorize("#root instanceof T(net.md_5.bungee.api.connection.ProxiedPlayer)")
 public @interface ProxiedPlayerOnly {
 
     /**
      * The message to be thrown in {@link PermissionDeniedException PermissionDeniedException}
      * if the sender is not a player.
      */
-    @AliasFor(annotation = PluginAuthorize.class, attribute = "message")
+    @AliasFor(annotation = Authorize.class, attribute = "message")
     String message() default "";
 
 }

--- a/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/OpOnly.java
+++ b/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/OpOnly.java
@@ -2,7 +2,7 @@ package xyz.quartzframework.spigot.security;
 
 import org.springframework.core.annotation.AliasFor;
 import xyz.quartzframework.core.exception.PermissionDeniedException;
-import xyz.quartzframework.core.security.PluginAuthorize;
+import xyz.quartzframework.core.security.Authorize;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,14 +14,14 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PluginAuthorize("isOp()")
+@Authorize("isOp()")
 public @interface OpOnly {
 
     /**
      * The message to be thrown in {@link PermissionDeniedException PermissionDeniedException}
      * if the sender is not a operator.
      */
-    @AliasFor(annotation = PluginAuthorize.class, attribute = "message")
+    @AliasFor(annotation = Authorize.class, attribute = "message")
     String message() default "";
 
 }

--- a/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/PlayerOnly.java
+++ b/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/PlayerOnly.java
@@ -2,7 +2,7 @@ package xyz.quartzframework.spigot.security;
 
 import org.springframework.core.annotation.AliasFor;
 import xyz.quartzframework.core.exception.PermissionDeniedException;
-import xyz.quartzframework.core.security.PluginAuthorize;
+import xyz.quartzframework.core.security.Authorize;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -14,14 +14,14 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PluginAuthorize("#root instanceof T(org.bukkit.entity.Player)")
+@Authorize("#root instanceof T(org.bukkit.entity.Player)")
 public @interface PlayerOnly {
 
     /**
      * The message to be thrown in {@link PermissionDeniedException PermissionDeniedException}
      * if the sender is not a player.
      */
-    @AliasFor(annotation = PluginAuthorize.class, attribute = "message")
+    @AliasFor(annotation = Authorize.class, attribute = "message")
     String message() default "";
 
 }

--- a/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/SpigotSecurityAspect.java
+++ b/quartz-spigot-plugin-starter/src/main/java/xyz/quartzframework/spigot/security/SpigotSecurityAspect.java
@@ -14,7 +14,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import xyz.quartzframework.core.exception.PermissionDeniedException;
 import xyz.quartzframework.core.exception.PlayerNotFoundException;
-import xyz.quartzframework.core.security.PluginAuthorize;
+import xyz.quartzframework.core.security.Authorize;
 import xyz.quartzframework.core.util.AopAnnotationUtils;
 import xyz.quartzframework.spigot.session.SpigotSession;
 import xyz.quartzframework.spigot.session.SpigotSessionService;
@@ -37,10 +37,10 @@ public class SpigotSecurityAspect {
 
     private final ExpressionParser parser = new SpelExpressionParser();
 
-    @Around("within(@(@xyz.quartzframework.core.security.PluginAuthorize *) *) " +
-            "|| execution(@(@xyz.quartzframework.core.security.PluginAuthorize *) * *(..)) " +
-            "|| @within(xyz.quartzframework.core.security.PluginAuthorize)" +
-            "|| execution(@xyz.quartzframework.core.security.PluginAuthorize * *(..))")
+    @Around("within(@(@xyz.quartzframework.core.security.Authorize *) *) " +
+            "|| execution(@(@xyz.quartzframework.core.security.Authorize *) * *(..)) " +
+            "|| @within(xyz.quartzframework.core.security.Authorize)" +
+            "|| execution(@xyz.quartzframework.core.security.Authorize * *(..))")
     public Object checkPermission(ProceedingJoinPoint joinPoint) throws Throwable {
         val sender = session.getSender();
         if (sender == null) {
@@ -52,7 +52,7 @@ public class SpigotSecurityAspect {
         IntStream.range(0, parameters.length)
                 .forEach(i -> senderContext.setVariable(parameters[i].getName(), joinPoint.getArgs()[i]));
         senderContext.setVariable("session", sessionService.current());
-        AopAnnotationUtils.getApplicableAnnotations(method, PluginAuthorize.class).forEach(pluginAuthorize -> {
+        AopAnnotationUtils.getApplicableAnnotations(method, Authorize.class).forEach(pluginAuthorize -> {
             val expressionSource = pluginAuthorize.value();
             val expression = expressionCache.computeIfAbsent(expressionSource, parser::parseExpression);
             senderContext.setVariable("params", pluginAuthorize.params());


### PR DESCRIPTION
… (development)

- Updated security annotations and aspects to use Authorize instead of PluginAuthorize for both Bungee and Spigot plugins.
- Modified ProxiedPlayerOnly, PlayerOnly, and OpOnly annotations.
- Updated BungeeSecurityAspect and SpigotSecurityAspect to reflect changes in annotation usage.